### PR TITLE
Use focusInline from getSelection(), not value, when blocking select

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-import { findRange, } from 'slate-react';
+import { findRange } from 'slate-react'
 
 import { ARROW_LEFT, ARROW_RIGHT, BACKSPACE, DELETE, ZERO_WIDTH_SPACE } from './constants'
 import onArrowLeft from './onArrowLeft'
@@ -99,16 +99,21 @@ function StickyInlines(opts) {
    */
 
   function onSelect(event, change) {
-    const selection = findRange(window.getSelection(), change.value);
-    const selectionIsAtEndOfInline = change.value.focusInline &&
-      selection.focusOffset === change.value.focusInline.text.length;
+    if (!change.value.focusInline) return null
+    const selection = findRange(window.getSelection(), change.value)
+    if (!selection) return null
+    const focusInline = change.value.document.getClosestInline(selection.anchorKey)
+    if (!focusInline) return null
+
+    const selectionIsAtEndOfInline = focusInline.key === change.value.focusInline.key &&
+      selection.focusOffset === focusInline.text.length
 
     if (
-      change.value.isCollapsed &&
+      selection.isCollapsed &&
       selectionIsAtEndOfInline
-    ) { return change; }
+    ) { return change }
 
-    return null;
+    return null
   }
 
   /**


### PR DESCRIPTION
At the time `onSelect` is called on a plugin, `change.value.selection` hasn't been updated with the new selection. Since we block onSelect based on `change.value.selection.focusInline`, this means that you can end up blocking selection incorrectly in the following case:

1. Select an inline that's 3 characters long
2. Select character 3 of any other node
3. Watch as change.value.selection isn't updated with the new cursor position

Here's an example: 

<img width="878" alt="2018-05-27 at 3 40 pm" src="https://user-images.githubusercontent.com/1020/40591391-269eec88-61c5-11e8-993b-ad60ea45e232.png">

This change relies on `window.getSelection()` for every check, and double-checks `focusInline.key`, ensuring that we'll update the selection when clicking on a different node.